### PR TITLE
Add script/bootstrap and update .zshrc, README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,19 +3,28 @@
 This repo contains a collection of my dotfiles. Suggestions and contributions are welcome!
 
 # Installation
-## Packages/plugins used:
 
-* zsh
-  * [oh-my-zsh](https://github.com/robbyrussell/oh-my-zsh)
+To install all the packages and plugins listed below, clone this repo and run `script/bootstrap`.
 
-* tmux
+## Packages/Plugins
+
+* [hyper](https://hyper.is)
+  * [.hyper-windows.js](hyper/.hyper-windows.js)
+
+* [keychain](https://packages.ubuntu.com/bionic/keychain)
+
+* [tmux](https://packages.ubuntu.com/bionic/tmux)
   * [tmuxinator](https://github.com/tmuxinator/tmuxinator)
 
-* vim
+* [vim](https://packages.ubuntu.com/bionic/vim)
   * [colorizer](https://github.com/lilydjwg/colorizer)
   * [NERDTree](https://github.com/scrooloose/nerdtree)
   * [pathogen](https://github.com/tpope/vim-pathogen)
   * [vim-surround](https://github.com/tpope/vim-surround)
 
-* [hyper](https://hyper.is)
-  * [.hyper-windows.js](hyper/.hyper-windows.js) is the configuration I use on Windows machines, but should be renamed `.hyper.js` to use.
+* [zsh](https://packages.ubuntu.com/bionic/zsh)
+  * [oh-my-zsh](https://github.com/robbyrussell/oh-my-zsh)
+
+# Compatibilty
+
+Tested on Ubuntu 18.04 for WSL. Should also work on Ubuntu 18.04.

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -1,0 +1,82 @@
+#!/bin/bash -e
+
+echo "--------------------------------"
+echo "Installing Dependencies"
+echo "--------------------------------"
+apt-get update && apt-get upgrade -y
+
+apt-get install -y \
+	apt-transport-https \
+	ca-certificates \
+	curl \
+	gnupg \
+	gnupg-agent \
+	keychain \
+	ruby \
+	software-properties-common \
+	tmux \
+	vim \
+	zsh
+
+echo "--------------------------------"
+echo "Installing Docker"
+echo "--------------------------------"
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
+add-apt-repository \
+	"deb [arch=amd64] https://download.docker.com/linux/ubuntu \
+	$(lsb_release -cs) \
+	stable"
+apt-get update && apt-get install -y docker-ce docker-ce-cli
+
+curl -L "https://github.com/docker/compose/releases/download/1.23.2/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
+chmod +x /usr/local/bin/docker-compose
+
+base=https://github.com/docker/machine/releases/download/v0.16.0 
+curl -L $base/docker-machine-$(uname -s)-$(uname -m) >/tmp/docker-machine
+install /tmp/docker-machine /usr/local/bin/docker-machine
+
+echo "--------------------------------"
+echo "Updating RubyGems"
+echo "--------------------------------"
+gem update --system
+
+echo "--------------------------------"
+echo "Installing Oh My Zsh"
+echo "--------------------------------"
+git clone https://github.com/robbyrussell/oh-my-zsh.git ~/.oh-my-zsh
+
+echo "--------------------------------"
+echo "Installing Tmuxinator"
+echo "--------------------------------"
+gem install tmuxinator
+
+echo "--------------------------------"
+echo "Installing Vim Plugins"
+echo "--------------------------------"
+mkdir -p ~/.vim/autoload ~/.vim/bundle
+curl -LSso ~/.vim/autoload/pathogen.vim https://tpo.pe/pathogen.vim
+
+git clone https://github.com/lilydjwg/colorizer ~/.vim/bundle
+git clone https://github.com/scrooloose/nerdtree.git ~/.vim/bundle/nerdtree
+git clone https://tpope.io/vim/surround.git ~/.vim/bundle/surround
+
+echo "--------------------------------"
+echo "Copying Files"
+echo "--------------------------------"
+cp tmux/sysinfo.sh /usr/bin
+cp tmux/.tmux.conf ~/.tmux.conf
+mkdir ~/.tmuxinator && cp tmuxinator/erhbg.yml ~/.tmuxinator/erhbg.yml
+cp vim/.vimrc ~/.vimrc
+mkdir -p ~/.oh-my-zsh/themes && cp zsh/erhbg.zsh-theme ~/.oh-my-zsh/themes/erhbg.zsh-theme
+cp zsh/.zshrc ~/.zshrc
+
+if grep -q Microsoft /proc/version; then
+	winUser=$(echo `/mnt/c/Windows/System32/cmd.exe /c "echo %USERNAME%"` | tr -d '\r')
+	if [ -e /mnt/c/Users/$winUser/.hyper.js ]; then
+		cp hyper/.hyper-windows.js /mnt/c/Users/$winUser/.hyper.js
+	else
+		echo "No installation found for Hyper, skip copying config."
+	fi
+else
+	echo "Not a WSL install, will not copy Hyper config."
+fi

--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -18,7 +18,6 @@ plugins=(
 )
 
 source $ZSH/oh-my-zsh.sh
-source /usr/share/rvm/scripts/rvm
 
 # Custom aliases
 alias c="clear"


### PR DESCRIPTION
This commit adds `script/bootstrap` to automate installation of packages and plugins used in my dev environment.
It also removes the line sourcing rvm from `.zshrc` as I am no longer using rvm.
Finally, this commit updates the README to add instructions on using `script/bootstrap` as well as other minor changes.